### PR TITLE
chore(tf): added `sensitive` argument to output.

### DIFF
--- a/internal/templates/frontend.tf.gtpl
+++ b/internal/templates/frontend.tf.gtpl
@@ -18,7 +18,8 @@ output "frontend_client_id_{{ $store.Key }}" {
 }
 
 output "frontend_client_secret_{{ $store.Key }}" {
-  value = commercetools_api_client.frontend_credentials_{{ $store.Key }}.secret
+  value     = commercetools_api_client.frontend_credentials_{{ $store.Key }}.secret
+  sensitive = true
 }
 {{ end }}
 {{ else }}


### PR DESCRIPTION
To avoid errors like:

```
╷
│ Error: Output refers to sensitive values
│
│   on site.tf line 184:
│  184: output "frontend_client_secret" {
│
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
```
See: https://github.com/labdigital-frasers/mach-config-dev/actions/runs/4244614013/jobs/7378974149

This was discovered while testing a release to the pg1 account using mach-composer 2.6.6. and tf 1.2.