### PR TITLE
feat: remove null resource dependency

### DIFF
--- a/.changes/unreleased/Removed-20231109-105020.yaml
+++ b/.changes/unreleased/Removed-20231109-105020.yaml
@@ -1,0 +1,3 @@
+kind: Removed
+body: null_resource and depends_on on modules using commercetools integration
+time: 2023-11-09T10:50:20.105133+01:00

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
+vendor
 mach-composer-plugin-*

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -142,7 +142,6 @@ func (p *Plugin) RenderTerraformComponent(site string, component string) (*schem
 
 	result := &schema.ComponentSchema{
 		Variables: vars,
-		DependsOn: []string{"null_resource.commercetools"},
 	}
 	return result, nil
 }

--- a/internal/templates/main.tf.gtpl
+++ b/internal/templates/main.tf.gtpl
@@ -89,23 +89,6 @@ output "frontend_channels" {
     ]
 }
 
-resource "null_resource" "commercetools" {
-  depends_on = [
-    {{ if .Config.ProjectSettings }}
-    commercetools_project_settings.project,
-    {{ end }}
-    {{ range $channel := .Config.Channels }}
-    commercetools_channel.{{ $channel.Key }},
-    {{ end }}
-    {{ if .Config.Taxes }}
-    commercetools_tax_category.standard,
-    {{ end }}
-    {{ range $store := .Config.ManagedStores }}
-    commercetools_store.{{ $store.Key }},
-    {{ end }}
-  ]
-}
-
 {{ if .Config.Stores }}
   {{ template "stores.tf.gtpl" . }}
 {{ end }}


### PR DESCRIPTION
We probably don't need this dependency anymore.
This was in place because MACH composer could manage commercetools resources as well, but we shift more and more towards having commercetools resources (settings, stores, channels, etc) in a separate and dedicated component.